### PR TITLE
Remove Equatable from ScannableFingerprint

### DIFF
--- a/Sources/SwiftSignal/Fingerprint.swift
+++ b/Sources/SwiftSignal/Fingerprint.swift
@@ -24,12 +24,6 @@ class ScannableFingerprint {
     }
 }
 
-extension ScannableFingerprint: Equatable {
-    static func == (lhs: ScannableFingerprint, rhs: ScannableFingerprint) -> Bool {
-        return try! lhs.compareWith(other: rhs)
-    }
-}
-
 class Fingerprint {
     let scannable : ScannableFingerprint
     let displayable: DisplayableFingerprint


### PR DESCRIPTION
`compareWith(other:)` is for checking a scanned key against an expected key, which wants to have the "local" and "remote" parts reversed (see the implementation of `ScannableFingerprint::compare` in [libsignal-protocol-rust](https://github.com/signalapp/libsignal-protocol-rust)). Equatable, on the other hand, wants `x == x` to be true.