### PR TITLE
Make all byte buffer inputs accept any ContiguousBytes type 

### DIFF
--- a/Sources/SignalProtocol/Kdf.swift
+++ b/Sources/SignalProtocol/Kdf.swift
@@ -1,24 +1,26 @@
 import SignalFfi
+import Foundation
 
-public func hkdf(outputLength: Int,
-                 version: UInt32,
-                 inputKeyMaterial: [UInt8],
-                 salt: [UInt8],
-                 info: [UInt8]) throws -> [UInt8] {
-
+public func hkdf<InputBytes, SaltBytes, InfoBytes>(outputLength: Int,
+                                                   version: UInt32,
+                                                   inputKeyMaterial: InputBytes,
+                                                   salt: SaltBytes,
+                                                   info: InfoBytes) throws -> [UInt8]
+where InputBytes: ContiguousBytes, SaltBytes: ContiguousBytes, InfoBytes: ContiguousBytes {
     var output = Array(repeating: UInt8(0x00), count: outputLength)
 
-    let error = signal_hkdf_derive(&output,
-                                   outputLength,
-                                   Int32(version),
-                                   inputKeyMaterial,
-                                   inputKeyMaterial.count,
-                                   salt,
-                                   salt.count,
-                                   info,
-                                   info.count)
-
-    try checkError(error)
+    try inputKeyMaterial.withUnsafeBytes { inputBytes in
+        try salt.withUnsafeBytes { saltBytes in
+            try info.withUnsafeBytes { infoBytes in
+                try checkError(signal_hkdf_derive(&output,
+                                                  outputLength,
+                                                  Int32(version),
+                                                  inputBytes.baseAddress?.assumingMemoryBound(to: UInt8.self), inputBytes.count,
+                                                  saltBytes.baseAddress?.assumingMemoryBound(to: UInt8.self), saltBytes.count,
+                                                  infoBytes.baseAddress?.assumingMemoryBound(to: UInt8.self), infoBytes.count))
+            }
+        }
+    }
 
     return output
 }

--- a/Sources/SignalProtocol/messages/PreKeySignalMessage.swift
+++ b/Sources/SignalProtocol/messages/PreKeySignalMessage.swift
@@ -1,4 +1,5 @@
 import SignalFfi
+import Foundation
 
 public class PreKeySignalMessage {
     private var handle: OpaquePointer?
@@ -7,8 +8,12 @@ public class PreKeySignalMessage {
         signal_pre_key_signal_message_destroy(handle)
     }
 
-    public init(bytes: [UInt8]) throws {
-        try checkError(signal_pre_key_signal_message_deserialize(&handle, bytes, bytes.count))
+    public init<Bytes: ContiguousBytes>(bytes: Bytes) throws {
+        handle = try bytes.withUnsafeBytes {
+            var result: OpaquePointer?
+            try checkError(signal_pre_key_signal_message_deserialize(&result, $0.baseAddress?.assumingMemoryBound(to: UInt8.self), $0.count))
+            return result
+        }
     }
 
     public init(version: UInt8,

--- a/Sources/SignalProtocol/messages/SenderKeyDistributionMessage.swift
+++ b/Sources/SignalProtocol/messages/SenderKeyDistributionMessage.swift
@@ -1,4 +1,5 @@
 import SignalFfi
+import Foundation
 
 public class SenderKeyDistributionMessage {
     private var handle: OpaquePointer?
@@ -18,17 +19,20 @@ public class SenderKeyDistributionMessage {
         }
     }
 
-    public init(keyId: UInt32,
-                iteration: UInt32,
-                chainKey: [UInt8],
-                publicKey: PublicKey) throws {
-
-        try checkError(signal_sender_key_distribution_message_new(&handle,
-                                                                  keyId,
-                                                                  iteration,
-                                                                  chainKey,
-                                                                  chainKey.count,
-                                                                  publicKey.nativeHandle))
+    public init<Bytes: ContiguousBytes>(keyId: UInt32,
+                                        iteration: UInt32,
+                                        chainKey: Bytes,
+                                        publicKey: PublicKey) throws {
+        handle = try chainKey.withUnsafeBytes {
+            var result: OpaquePointer?
+            try checkError(signal_sender_key_distribution_message_new(&result,
+                                                                      keyId,
+                                                                      iteration,
+                                                                      $0.baseAddress?.assumingMemoryBound(to: UInt8.self),
+                                                                      $0.count,
+                                                                      publicKey.nativeHandle))
+            return result
+        }
     }
 
     public init(bytes: [UInt8]) throws {

--- a/Sources/SignalProtocol/messages/SenderKeyMessage.swift
+++ b/Sources/SignalProtocol/messages/SenderKeyMessage.swift
@@ -1,4 +1,5 @@
 import SignalFfi
+import Foundation
 
 public class SenderKeyMessage {
     private var handle: OpaquePointer?
@@ -7,21 +8,28 @@ public class SenderKeyMessage {
         signal_sender_key_message_destroy(handle)
     }
 
-    public init(keyId: UInt32,
-                iteration: UInt32,
-                ciphertext: [UInt8],
-                privateKey: PrivateKey) throws {
-
-        try checkError(signal_sender_key_message_new(&handle,
-                                                     keyId,
-                                                     iteration,
-                                                     ciphertext,
-                                                     ciphertext.count,
-                                                     privateKey.nativeHandle))
+    public init<Bytes: ContiguousBytes>(keyId: UInt32,
+                                        iteration: UInt32,
+                                        ciphertext: Bytes,
+                                        privateKey: PrivateKey) throws {
+        handle = try ciphertext.withUnsafeBytes {
+            var result: OpaquePointer?
+            try checkError(signal_sender_key_message_new(&result,
+                                                         keyId,
+                                                         iteration,
+                                                         $0.baseAddress?.assumingMemoryBound(to: UInt8.self),
+                                                         $0.count,
+                                                         privateKey.nativeHandle))
+            return result
+        }
     }
 
-    public init(bytes: [UInt8]) throws {
-        try checkError(signal_sender_key_message_deserialize(&handle, bytes, bytes.count))
+    public init<Bytes: ContiguousBytes>(bytes: Bytes) throws {
+        handle = try bytes.withUnsafeBytes {
+            var result: OpaquePointer?
+            try checkError(signal_sender_key_message_deserialize(&result, $0.baseAddress?.assumingMemoryBound(to: UInt8.self), $0.count))
+            return result
+        }
     }
 
     public func keyId() throws -> UInt32 {

--- a/Sources/SignalProtocol/state/PreKeyRecord.swift
+++ b/Sources/SignalProtocol/state/PreKeyRecord.swift
@@ -1,4 +1,5 @@
 import SignalFfi
+import Foundation
 
 public class PreKeyRecord: ClonableHandleOwner {
     private var handle: OpaquePointer?
@@ -11,9 +12,12 @@ public class PreKeyRecord: ClonableHandleOwner {
         return signal_pre_key_record_clone(&newHandle, currentHandle)
     }
 
-    public init(bytes: [UInt8]) throws {
-        var handle: OpaquePointer?
-        try checkError(signal_pre_key_record_deserialize(&handle, bytes, bytes.count))
+    public init<Bytes: ContiguousBytes>(bytes: Bytes) throws {
+        let handle: OpaquePointer? = try bytes.withUnsafeBytes {
+            var result: OpaquePointer?
+            try checkError(signal_pre_key_record_deserialize(&result, $0.baseAddress?.assumingMemoryBound(to: UInt8.self), $0.count))
+            return result
+        }
         super.init(owned: handle!)
     }
 

--- a/Sources/SignalProtocol/state/SenderKeyRecord.swift
+++ b/Sources/SignalProtocol/state/SenderKeyRecord.swift
@@ -1,4 +1,5 @@
 import SignalFfi
+import Foundation
 
 public class SenderKeyRecord: ClonableHandleOwner {
     internal override class func destroyNativeHandle(_ handle: OpaquePointer) {
@@ -11,9 +12,12 @@ public class SenderKeyRecord: ClonableHandleOwner {
 
     private var handle: OpaquePointer?
 
-    public init(bytes: [UInt8]) throws {
-        var handle: OpaquePointer?
-        try checkError(signal_sender_key_record_deserialize(&handle, bytes, bytes.count))
+    public init<Bytes: ContiguousBytes>(bytes: Bytes) throws {
+        let handle: OpaquePointer? = try bytes.withUnsafeBytes {
+            var result: OpaquePointer?
+            try checkError(signal_sender_key_record_deserialize(&result, $0.baseAddress?.assumingMemoryBound(to: UInt8.self), $0.count))
+            return result
+        }
         super.init(owned: handle!)
     }
 

--- a/Sources/SignalProtocol/state/SessionRecord.swift
+++ b/Sources/SignalProtocol/state/SessionRecord.swift
@@ -1,4 +1,5 @@
 import SignalFfi
+import Foundation
 
 public class SessionRecord: ClonableHandleOwner {
     internal override class func destroyNativeHandle(_ handle: OpaquePointer) {
@@ -9,9 +10,12 @@ public class SessionRecord: ClonableHandleOwner {
         return signal_session_record_clone(&newHandle, currentHandle)
     }
 
-    public init(bytes: [UInt8]) throws {
-        var handle: OpaquePointer?
-        try checkError(signal_session_record_deserialize(&handle, bytes, bytes.count))
+    public init<Bytes: ContiguousBytes>(bytes: Bytes) throws {
+        let handle: OpaquePointer? = try bytes.withUnsafeBytes {
+            var result: OpaquePointer?
+            try checkError(signal_session_record_deserialize(&result, $0.baseAddress?.assumingMemoryBound(to: UInt8.self), $0.count))
+            return result
+        }
         super.init(owned: handle!)
     }
 


### PR DESCRIPTION
This helps avoid unnecessary conversions on the client side, at the cost of some burden on us giving up the array-to-pointer conversion and dealing with the `void *` / `unsigned char *` mismatch.

It's also possible for this to be a performance hazard because of the extra indirection; in that case we'll want to mark some or all of these as inlinable so the compiler can optimize that away. (That's non-trivial because some of them touch private instance data. It's also something that shouldn't really be necessary for non-stable libraries but as far as I know that isn't present in Swift 5.2 or 5.3.)