### PR TITLE
PR testing: update for changes to libsignal-ffi's install name

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,7 @@ jobs:
         run: make -C libsignal-ffi
 
       - name: Build libsignal-protocol-swift and run tests
-        run: swift test -v --enable-code-coverage
+        run: swift test -v --enable-code-coverage -Xlinker -rpath -Xlinker $PKG_CONFIG_PATH
 
       - name: Generate coverage report
         run: xcrun llvm-cov show --format=html --instr-profile .build/x86_64-apple-macosx/debug/codecov/default.profdata .build/x86_64-apple-macosx/debug/*.xctest/Contents/MacOS/* Sources --output-dir coverage-report


### PR DESCRIPTION
Required after signalapp/libsignal-ffi#13.